### PR TITLE
Update FFmpeg.AutoGen from 5.1.1 to 6.0.0

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FFmpeg.AutoGen" Version="5.1.1" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="6.0.0" />
     <PackageReference Include="LibUsbDotNet" Version="3.0.102-alpha" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.82" />
     <PackageReference Include="SharpRTSP" Version="1.0.0" />


### PR DESCRIPTION
Updating to the latest version (6.0.0 at the date of this commit) solves the issue `System.DllNotFoundException: Unable to load DLL 'avcodec.59 under ': The specified module could not be found` and #208 on Linux operating systems. Unfortunately i can't test it because i don't own a Nintendo Switch.

Output: 
```
Basic usage:
...
Press enter to continue.


Initializing video player with h264 codec.
ERROR: SysDVR usb device not found.
Make sure that SysDVR is running in usb mode on your console and that you installed the correct driver.
SysDVR protocol may change with updates, SysDVR on your console must be the same version as the client !
```

As i said before i don't have a switch so that's why it throws that ERROR msg