### PR TITLE
refactor: remove unnecesary manual work

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
 		<Platforms>AnyCPU</Platforms>
 		<AssemblyName>SysDVR-Client</AssemblyName>
 		<Description>https://github.com/exelix11/SysDVR</Description>
@@ -7,50 +8,40 @@
 		<Company />
 		<PackageProjectUrl>https://github.com/exelix11/SysDVR</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/exelix11/SysDVR</RepositoryUrl>
-		<Version>6.1.1</Version>
 		<RootNamespace>SysDVR.Client</RootNamespace>
-		<AssemblyVersion>6.1.1</AssemblyVersion>
-		<FileVersion>6.1.1</FileVersion>
-		<Configurations>Debug;Release</Configurations>
 		<ApplicationIcon>Client.ico</ApplicationIcon>
 		<RollForward>Major</RollForward>
-		<PublishAot>true</PublishAot>
 		<Nullable>annotations</Nullable>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
-	<Choose>
-		<!--Android and macos builds use dotnet 8 preview-->
-		<When Condition="$(SysDvrTarget)=='android'">
-			<PropertyGroup>
-				<TargetFramework>net8.0</TargetFramework>
-				<DefineConstants>$(DefineConstants);ANDROID_LIB</DefineConstants>
-				<PublishAotUsingRuntimePack>true</PublishAotUsingRuntimePack>
-			</PropertyGroup>
-			<ItemGroup>
-				<!--Android needs a proper soname property or it will refuse to load the library-->
-				<LinkerArg Include="-Wl,-soname,SysDVR-Client.so" />
-			</ItemGroup>
-		</When>
+	<PropertyGroup Condition="$(SysDvrTarget)!='android'">
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
 
-		<!--As of now the only difference is android, instead of using specific conditions we can just use an Otherwise block-->
-		<!--<When Condition="$(SysDvrTarget)=='macos'">-->
-		<!--<When Condition="$(SysDvrTarget)=='linux'">-->
-		<!--<When Condition="$(SysDvrTarget)=='windows'">-->
-		<Otherwise>
-			<PropertyGroup>
-				<OutputType>Exe</OutputType>
-				<TargetFramework>net8.0</TargetFramework>
-			</PropertyGroup>
-		</Otherwise>
-	</Choose>
+	<PropertyGroup Condition="$(SysDvrTarget)=='windows'">
+		<PublishAot>true</PublishAot>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(SysDvrTarget)=='linux'">
+		<PublishAotUsingRuntimePack>true</PublishAotUsingRuntimePack>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(SysDvrTarget)=='android'">
+		<DefineConstants>$(DefineConstants);ANDROID_LIB</DefineConstants>
+		<PublishAotUsingRuntimePack>true</PublishAotUsingRuntimePack>
+	</PropertyGroup>
+
+	<ItemGroup Condition="$(SysDvrTarget)=='android'">
+		<!--Android needs a proper soname property or it will refuse to load the library-->
+		<LinkerArg Include="-Wl,-soname,SysDVR-Client.so" />
+	</ItemGroup>
 	
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Optimize>false</Optimize>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<DebugType>none</DebugType>
 		<DebugSymbols>false</DebugSymbols>
 	</PropertyGroup>
@@ -74,37 +65,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="System.Text.Json" Version="7.0.3" />
+	  <PackageReference Include="GitInfo" Version="3.3.5">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Include="System.Text.Json" Version="8.0.4" />
 	</ItemGroup>
-
-	<!-- The following tasks are used to stamp the git commit hash into the binary -->
-	<PropertyGroup>
-		<!-- Default value in case git is not installed -->
-		<GitCommitHash>unknown</GitCommitHash>
-	</PropertyGroup>
-	
-	<Target Name="CreateGitAttributeFile" BeforeTargets="CoreCompile">
-		<!-- Try to run git and get the commit hash -->
-		<Exec Command="git rev-parse --short HEAD" ConsoleToMSBuild="True" IgnoreExitCode="True">
-			<Output TaskParameter="ExitCode" PropertyName="GitTaskExitCode" />
-			<Output Condition="'$(GitTaskExitCode)'=='0'" PropertyName="GitCommitHash" TaskParameter="ConsoleOutput" />
-		</Exec>
-		<!-- names the obj/.../CustomAssemblyInfo.cs file -->
-		<PropertyGroup>
-			<CustomAssemblyInfoFile>$(IntermediateOutputPath)CustomAssemblyInfo.cs</CustomAssemblyInfoFile>
-		</PropertyGroup>
-		<!-- includes the CustomAssemblyInfo for compilation into your project -->
-		<ItemGroup>
-			<Compile Include="$(CustomAssemblyInfoFile)" />
-		</ItemGroup>
-		<!-- defines the AssemblyMetadata attribute that will be written -->
-		<ItemGroup>
-			<AssemblyAttributes Include="AssemblyMetadata">
-				<_Parameter1>BuildCommit</_Parameter1>
-				<_Parameter2>$(GitCommitHash)</_Parameter2>
-			</AssemblyAttributes>
-		</ItemGroup>
-		<!-- writes the attribute to the customAssemblyInfo file -->
-		<WriteCodeFragment Language="C#" OutputFile="$(CustomAssemblyInfoFile)" AssemblyAttributes="@(AssemblyAttributes)" />
-	</Target>
 </Project>

--- a/Client/Platform/Resources.cs
+++ b/Client/Platform/Resources.cs
@@ -173,22 +173,6 @@ namespace SysDVR.Client.Platform
 		public readonly static LazyImage UsbIcon = new LazyImage(ResourcePath("ico_usb.png"));
 		public readonly static LazyImage WifiIcon = new LazyImage(ResourcePath("ico_wifi.png"));
 
-		public static string? GetBuildId()
-		{
-			try
-			{
-				// Reflection doesn't usually work with AOT but this is a special case
-				return typeof(Program).Assembly
-					.GetCustomAttributes<AssemblyMetadataAttribute>()
-					.FirstOrDefault(a => a.Key == "BuildCommit")?.Value;
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine("Couldn't load build id file" + ex.ToString());
-			}
-
-			return null;
-		}
 
         public static StringTableMetadata[] GetAvailableTranslations()
         {

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -2,12 +2,11 @@
 using SysDVR.Client.Core;
 using SysDVR.Client.GUI.Components;
 using SysDVR.Client.Platform;
-using SysDVR.Client.Test;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 #if ANDROID_LIB
@@ -57,8 +56,9 @@ namespace SysDVR.Client
 
 		static readonly StringBuilder InitializationError = new();
 
-		public static string Version = "6.1.1";
-		public static string BuildID = "";
+        [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "It works here")]
+        public static readonly string Version = ThisAssembly.Git.BaseTag.ToString();
+        public static readonly string BuildID = ThisAssembly.Git.Commit.ToString();
 
 		public static Options Options = new();
 
@@ -127,8 +127,6 @@ namespace SysDVR.Client
 				if (Instance is null && LegacyInstance is null)
 				{
 					DynamicLibraryLoader.Initialize();
-
-					BuildID = Resources.GetBuildId() ?? "unknown";
 
 					Console.WriteLine($"SysDVR-Client {Version} - by exelix");
 					Console.WriteLine("https://github.com/exelix11/SysDVR");


### PR DESCRIPTION
hi!

i was looking at how you made the UI cross platform as im trying out Avalonia at the moment. 
while looking around i saw a lot of manual work that i don't understand why.
I replaced the GIT stuff with GitInfo which compiles it for you at compile time, and cleaned up the csproj while i was there as it was kinda a mess. you were using the System.Text.Json 7.0.4 while targeting .net 8 ...
im also not sure what all the constants stuff is about but thats for another time :)