### PR TITLE
Update flatpak build

### DIFF
--- a/Client/Platform/Linux/build-flatpak.sh
+++ b/Client/Platform/Linux/build-flatpak.sh
@@ -2,17 +2,8 @@
 
 set -e
 
-# install flatpak dependencies
-flatpak install --user -y flathub org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08 runtime/org.freedesktop.Sdk.Extension.dotnet6/x86_64/22.08
-
 if [ ! -d "shared-modules" ]; then
-	mkdir shared-modules
-	cd shared-modules
-	git init
-	git remote add origin https://github.com/flathub/shared-modules.git
-	git fetch --depth 1 origin d88a9156b91eef64ecf1a313c868f1401c4bb39b
-	git checkout FETCH_HEAD
-	cd ..
+	git clone --depth 1 https://github.com/flathub/shared-modules.git
 fi
 
 cd .. # Go to Platforms folder
@@ -41,5 +32,5 @@ fi
 mkdir -p dvr-build
 cp -r ../../bin/Release/net8.0/linux-x64/publish/* dvr-build/
 
-flatpak-builder --user --install tmp com.github.exelix11.sysdvr.json --force-clean
+flatpak-builder --user --install --install-deps-from=flathub tmp com.github.exelix11.sysdvr.json --force-clean
 flatpak build-bundle ~/.local/share/flatpak/repo SysDVR-Client.flatpak com.github.exelix11.sysdvr --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo

--- a/Client/Platform/Linux/com.github.exelix11.sysdvr.desktop
+++ b/Client/Platform/Linux/com.github.exelix11.sysdvr.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=SysDVR-Client
+Comment=Stream switch games to your PC via USB or network
+Icon=com.github.exelix11.sysdvr
+Exec=SysDVR-Client
+Terminal=false
+Categories=Game;
+Keywords=Nintendo;Switch;

--- a/Client/Platform/Linux/com.github.exelix11.sysdvr.json
+++ b/Client/Platform/Linux/com.github.exelix11.sysdvr.json
@@ -1,58 +1,33 @@
 {
 	"app-id": "com.github.exelix11.sysdvr",
 	"runtime": "org.freedesktop.Platform",
-	"runtime-version": "22.08",
+	"runtime-version": "24.08",
 	"sdk": "org.freedesktop.Sdk",
 	"command": "SysDVR-Client",
 	"finish-args": [
 		"--share=ipc",
-		"--socket=x11",
+		"--socket=fallback-x11",
 		"--socket=wayland",
 		"--device=all",
 		"--share=network",
 		"--socket=pulseaudio",
 		"--filesystem=host"
 	],
-	"build-options": {
-		"env": {
-			"PKG_CONFIG_PATH": "/app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet6/lib/pkgconfig"
-		}
-	},
 	"modules": [
-		"shared-modules/SDL2/SDL2-no-libdecor.json",
 		"shared-modules/libusb/libusb.json",
 		{
-			"name": "SDL2_image",
-			"config-opts": ["--disable-static"],
-			"rm-configure": true,
-			"cleanup": [
-				"/include",
-				"/lib/pkgconfig",
-				"*.la",
-				"*.a"
-			],
-			"sources": [
-				{
-					"type": "archive",
-					"url": "https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.3/SDL2_image-2.6.3.tar.gz",
-					"sha256": "931c9be5bf1d7c8fae9b7dc157828b7eee874e23c7f24b44ba7eff6b4836312c"
-				}
-			]
-		},
-		{
 			"name": "ffmpeg",
-			"cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg/examples" ],
+			"cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg" ],
 			"config-opts": [
 			  "--enable-shared",
 			  "--disable-static",
-			  "--enable-gnutls",
 			  "--disable-doc",
 			  "--disable-programs"
 			],
 			"sources": [{
 			  "type": "archive",
-			  "url": "https://ffmpeg.org/releases/ffmpeg-5.1.tar.xz",
-			  "sha256": "55eb6aab5ee235550fa54a33eaf8bf1b4ec66c01453182b12f6a993d75698b03"
+			  "url": "https://ffmpeg.org/releases/ffmpeg-5.1.6.tar.xz",
+			  "sha256": "f4fa066278f7a47feab316fef905f4db0d5e9b589451949740f83972b30901bd"
 			}]
 		  },
 		{
@@ -60,13 +35,25 @@
 			"buildsystem": "simple",
 			"build-commands":
 			[
-				"cp -r . /app/bin"
+				"ln -s /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 /app/lib/libSDL2.so",
+				"ln -s /usr/lib/x86_64-linux-gnu/libSDL2_image-2.0.so.0 /app/lib/libSDL2_image.so",
+				"ln -s /usr/lib/x86_64-linux-gnu/libSDL2_mixer-2.0.so.0 /app/lib/libSDL2_mixer.so",
+				"ln -s /usr/lib/x86_64-linux-gnu/libSDL2_net-2.0.so.0 /app/lib/libSDL2_net.so",
+				"ln -s /usr/lib/x86_64-linux-gnu/libSDL2_ttf-2.0.so.0 /app/lib/libSDL2_ttf.so",
+				"install -Dm644 com.github.exelix11.sysdvr.desktop /app/share/applications/com.github.exelix11.sysdvr.desktop",
+				"install -Dm644 dvr-build/runtimes/resources/logo.png /app/share/icons/hicolor/256x256/apps/com.github.exelix11.sysdvr.png",
+				"cp -r dvr-build /app/bin"
 			],
 			"sources":
 			[
 				{
 					"type": "dir",
-					"path": "dvr-build"
+					"path": "dvr-build",
+					"dest": "dvr-build"
+				},
+				{
+					"type": "file",
+					"path": "com.github.exelix11.sysdvr.desktop"
 				}
 			]
 		}


### PR DESCRIPTION
This updates several things in the flatpak build:
- The flatpak dependencies are automatically installed using the `--install-deps-from=flathub` parameter of `flatpak-builder`, instead of installing them explicitly.
- The runtime version has been updated to 24.08. This removes the need to pin `flathub/shared-modules` to an older commit.
- `--socket=x11` has been replaced by `--socket=fallback-x11`. This has no effect on x11 sessions, but removes the unneeded x11 socket on wayland sessions.
- Some unsed parts have been removed, including SDL2_image (the dependency is already included in the standard flatpak runtime, it just needs a couple of symlinks for it to be detected by dotnet).
- I've also updated ffmpeg to the latest version of the 5.1 series.
- A desktop file is included to make it possible to open SysDVR from the GUI menus, without having to open a terminal.

I've tested this with the latest sysmodule release and it's working fine on both network and usb modes.