### PR TITLE
fixed grammar for english.json

### DIFF
--- a/Client/Platform/Resources/resources/strings/english.json
+++ b/Client/Platform/Resources/resources/strings/english.json
@@ -27,7 +27,7 @@
     "error": "Fatal error",
     "autoConnect": "SysDVR will connect automatically to the first valid device",
     "autoConnectWithSerial": "SysDVR will connect automatically to the console with serial containing: {0}",
-    "autoConnectCancelButton": "Cancel auto conect",
+    "autoConnectCancelButton": "Cancel auto connect",
     "deviceNotCompatible": "The selected device is not compatible with this version of the client.\nMake sure you're using the same version of SysDVR on both the console and this device.",
     "connectionInProgress": "Connecting to console (attempt {0} out of {1}",
     "manualConnection": "Manual connection"
@@ -98,10 +98,10 @@
     "defaultStreaming_Video": "Video only",
     "defaultStreaming_Audio": "Audio only",
     "saveFailedError": "Failed to save settings",
-    "performanceRenderingLabel": "These options affect the rendering pipeline of the client, when enabling 'uncapped' modes SysDVR-client will sync to the vsync event of your device, this should remove any latency due to the rendering pipeline but mey use more power on mobile devices.",
+    "performanceRenderingLabel": "These options affect the rendering pipeline of the client, when enabling 'uncapped' modes SysDVR-client will sync to the vsync event of your device, this should remove any latency due to the rendering pipeline but may use more power on mobile devices.",
     "uncapStreaming": "Uncap streaming framerate",
     "uncapGUI": "Uncap GUI framerate",
-    "performanceStreamingLabel": "These options affect the straming quality of SysDVR, the defaults are usually fine",
+    "performanceStreamingLabel": "These options affect the streaming quality of SysDVR, the defaults are usually fine",
     "audioBatching": "Audio batching",
      // Translator note: NAL is the name of individual packets in a h264 video stream
 	"cachePackets": "Cache video packets (NAL) locally and replay them when needed",
@@ -153,7 +153,7 @@
     "noDevicesHelp": "Make sure you have SysDVR installed on your console and that it's running in USB mode.",
     "noDevicesHelpWindows": "The first time you run SysDVR on Windows you must install the USB driver, follow the guide.",
     "noDevicesHelpLinux": "To properly use USB mode on Linux you need to install the needed udev rule according to the guide",
-    "noDevicesHelpAndroid": "In case of issues make sure your device supports USB OTG, note that certain USB C to C cables are known to cause issues, try with a OTG adapter on your phone USB port",
+    "noDevicesHelpAndroid": "In case of issues make sure your device supports USB OTG, note that certain USB-C to USB-C cables are known to cause issues, try with a OTG adapter on your phone USB port",
     "refreshButton": "Refresh device list"
   },
   "errors": {
@@ -171,7 +171,7 @@
     "description": "SysDVR now uses standard Android ADB drivers\nThe driver is signed by Google, so it is safe to install and doesn't require any complex install steps.",
     "installButton": "Install",
     "checkAgainButton": "Check status again",
-    "installInfo": "If you choose to install the driver it will be downloaded from",
+    "installInfo": "If you choose to install the driver, it will be downloaded from",
     "fileHashInfo": "The expected SHA256 hash of the zip file is",
     "installing": "Installation in progress...",
     "statusDownload": "Downloading the driver...",
@@ -181,7 +181,7 @@
     "detectOk": "It seems the driver is already installed, unless you face issues, you DON'T need to install it again.",
     "detectNotInstalled": "It seems the driver is not installed, you need to install it to use SysDVR.",
     "detectNoDevice": "It seems that Windows has never detected the SysDVR device ID. Enable USB mode in SysDVR-Settings and connect your console. Note that USB-C to C cables may not work.",
-    "installSucceeded": "The installation was succesful",
+    "installSucceeded": "The installation was successful",
     "installFailed": "Installation failed",
     "detectionFailed": "Error while detecting the driver state"
   }


### PR DESCRIPTION
* replaced "conect" with "connect" (missing 2nd "n" char.")

* replaced "mey" with "may" ("mey" does not exist, correct word is "may")

* replaced "straming" with "streaming" (again, "straming" does not exist, grammar error.)

* replaced "succesful" with "successful" (missing 2nd "s" char.)

* added comma to "If you choose to install the driver, it will be downloaded from"

* updated "Note that certain USB C to C cables are known to cause issues..." to "Note that certain USB-C to USB-C cables are known to cause issues..."