### PR TITLE
grammar fix brazilianPortuguese.json

### DIFF
--- a/SysDVRConfig/romfs/strings/brazilianPortuguese.json
+++ b/SysDVRConfig/romfs/strings/brazilianPortuguese.json
@@ -1,12 +1,12 @@
 {
-  "LanguageName": "Brazilian portuguese",
+  "LanguageName": "Brazilian Portuguese",
   "FontName": "opensans.ttf",
   "ImguiGlyphRange": "Default",
   "TranslationAuthor": "discollizard",
   "Connecting": {
     "Description": "Se você acabou de ligar seu console, pode demorar até 20 segundos",
     "Title": "Conectando ao SysDVR...",
-    "Troubleshoot1": "Se você não consegue passar desta dela, o SysDVR não está rodando",
+    "Troubleshoot1": "Se você não consegue passar desta tela, o SysDVR não está rodando",
     "Troubleshoot2": "Certifique-se que seu setup está correto e reinicie seu console para continuar"
   },
   "Error": {
@@ -19,25 +19,25 @@
     "OlderVersion": "Você está usando uma versão desatualizada do SysDVR",
     "SysdvrVersionError": "Não foi possível saber a versão do SysDVR",
     "SysmoduleConnectionFailed": "Não foi possível conectar ao SysDVR.",
-    "SysmoduleConnectionTroubleshoot": "Se você acabou de instalar, reinicie seu console. Caso contrário, espere um pouco e tente novamente.\n Isto é normal se estiver usando uma versão do SysDVR que seja USB-Only.",
+    "SysmoduleConnectionTroubleshoot": "Se você acabou de instalar, reinicie seu console. Caso contrário, espere um pouco e tente novamente.\n Isso é normal se você estiver usando uma versão do SysDVR que funciona apenas via USB.",
     "SysmoduleConnectionTroubleshootLink": "Para suporte, veja a página de troubleshooting:",
     "TroubleshootBootMode": "Tente verificar que seu cartão SD não esteja corrompido",
     "TroubleshootReboot": "Tente reiniciar seu console",
     "VersionTroubleshoot": "Por favor, baixe a versão mais recente no Github",
     "NotInstalled" : "SysDVR não está instalado no seu console",
-	"NotInsalledSecondLine" : "O arquivo /atmosphere/contents/00FF0000A53BB665/exefs.nsp não foi encontrado no seu cartão SD. Isto significa que você não extraiu o zip do SysDVR corretamente. Conserte o problema e reinicie o console."
+	"NotInsalledSecondLine" : "O arquivo /atmosphere/contents/00FF0000A53BB665/exefs.nsp não foi encontrado no seu cartão SD. Isso significa que você não extraiu o zip do SysDVR corretamente. Conserte o problema e reinicie o console."
   },
   "Guide": {
     "GuideTitle": "O guia está hospedado no Github:"
   },
   "Main": {
     "ActiveMode": "Habilitado",
-    "ConsoleIPPlcaceholder": "<endreço de IP do console>",
+    "ConsoleIPPlcaceholder": "<endereço de IP do console>",
     "DefaultMode": "Ao inicializar",
     "ModeDisabled": "Parar de transmitir",
     "ModeRtsp": "Transmita diretamente para qualquer player de vídeo via RSTP.\nQuando você habilitar e aplicar, abra rtsp://{}:6666/ em qualquer player de vídeo, como MPV ou VLC.\nEste modo não requer o SysDVR-Client no seu PC.\nPara modos em rede, é recomendado que se use um adaptador LAN.",
     "ModeRtspTitle": "Modo de rede simples (RTSP)",
-    "ModeTcp": "Transmita a aplicação SysDVR-Client via rede. Isto é mais estável que o modo de rede simples.\nPara configurar SysDVR-Client no seu PC, consulte o guia no GitHub.\nPara modos em rede, é recomendado que se use um adaptador LAN.",
+    "ModeTcp": "Transmita a aplicação SysDVR-Client via rede. Isso é mais estável que o modo de rede simples.\nPara configurar SysDVR-Client no seu PC, consulte o guia no GitHub.\nPara modos em rede, é recomendado que se use um adaptador LAN.",
     "ModeTcpTitle": "TCP Bridge",
     "ModeUsb": "Use este modo para transmitir à aplicação SysDVR-Client USB.\nPara configurar SysDVR-Client no seu PC, consulte o guia no GitHub",
     "ModeUsbTitle": "USB",
@@ -52,7 +52,7 @@
     "CurlError": "Erro ao inicializar Curl",
     "CurlGETFailed": "Curl GET falhou",
     "CurlNoData": "Nenhum dado foi recebido",
-    "Description": "dvr-patches são patches do sistema que permitem a transmissão da maioria dos jogos incompatíveis com o SysDVR. Alguns jogos são ditos que não funcionam. Você pode ler mais no issue tracker em https://github.com/exelix11/dvr-patches.\nVocê pode também baixar o zip manualmente do repositório GitHub em um computador.",
+    "Description": "dvr-patches são patches do sistema que permitem a transmissão da maioria dos jogos incompatíveis com o SysDVR. Alguns jogos supostamente não funcionam. Você pode ler mais no issue tracker em https://github.com/exelix11/dvr-patches.\nVocê pode também baixar o zip manualmente do repositório GitHub em um computador.",
     "DownloadButton": "Baixar e instalar",
     "DownloadOk": "Atualização baixada.",
     "LatestVer": "Você já está usando a versão mais nova de dvr-patches.",
@@ -62,7 +62,7 @@
     "ParseDownloadFailure": "Erro ao encontrar link de download para a release",
     "ParseReleaseFailure": "Erro ao interpretar informações de release",
     "ParseTagCommitFailure": "Erro ao encontrar commit para tag",
-    "ParseTagFailure": "Erro ao interpretar informações de tags do GitHub",
+    "ParseTagFailure": "Erro ao interpretar informações das tags do GitHub",
     "RebootButton": "Reiniciar agora",
     "RebootWarning": "Para aplicar as mudanças, é necessário reiniciar o console    ",
     "SdcardPath": "Caminho do cartão SD:",


### PR DESCRIPTION
* changed "Brazilian portuguese" to "Brazilian Portuguese"

* replaced "dela" with "tela" ("dela" here must have been a mistake, the correct word is "tela" (screen))

* replaced all instances of "Isto" with "Isso" ("Isto" is more used in PT-PT, "Isso" is used in portuguese brazilian)

* replaced "Isto é normal se estiver usando uma versão do SysDVR que seja USB-Only." with "Isso é normal se você estiver usando uma versão do SysDVR que funciona apenas via USB." (better brazilian fluency)

* changed “Endreço” to "Endereço" (missing 2nd "e" char.)

* changed “de” with “das” (this is the correct form in this context)

* replaced "Alguns jogos são ditos que não funcionam" with "Alguns jogos supostamente não funcionam." (this phrase is extremely broken grammatically due to mixing incompatible structures, this is the correct way to say it)