### PR TITLE
Exit lbl when not needed

### DIFF
--- a/sysmodule/source/util.c
+++ b/sysmodule/source/util.c
@@ -18,8 +18,9 @@ bool UtilSetConsoleScreenMode(bool on)
 			else if (!on && lblstatus == LblBacklightSwitchStatus_Enabled)
 				rc = lblSwitchBacklightOff(0);
 		}
+		lblExit();
 	}
-
+	
 	LOG("UtilSetConsoleScreenMode(%d) %x", on, rc);
 	return R_SUCCEEDED(rc);
 }


### PR DESCRIPTION
lbl has basically only one session available for homebrew.

This PR stops blocking lbl for no reason.