### PR TITLE
Improve flatpak build

### DIFF
--- a/.github/workflows/client-linux-x64.yml
+++ b/.github/workflows/client-linux-x64.yml
@@ -6,29 +6,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
+      options: --privileged
     steps:
-    - uses: actions/checkout@v3
-    - name: Install flatpak
-      run: |
-        sudo apt update
-        sudo apt install flatpak flatpak-builder -y
-        flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
+    - uses: actions/checkout@v5
+    - name: Checkout shared-modules
+      uses: actions/checkout@v5
       with:
-        dotnet-version: "9.x"
-    - name: Cache flatpak builds
-      uses: actions/cache@v3
+        repository: flathub/shared-modules
+        path: Client/Platform/Linux/shared-modules
+    - name: Build flatpak bundle
+      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
       with:
-        path: Client/Platform/Linux/.flatpak-builder
-        key: flatpak-${{ runner.os }}
-    - name: Run build script
-      run: |
-        cd Client/Platform/Linux
-        chmod +x build-flatpak.sh
-        ./build-flatpak.sh
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: SysDVR-Client.flatpak
-        path: Client/Platform/Linux/SysDVR-Client.flatpak
+        manifest-path: ./Client/Platform/Linux/com.github.exelix11.sysdvr.json
+        bundle: SysDVR-Client.flatpak

--- a/Client/Platform/Linux/build-flatpak.sh
+++ b/Client/Platform/Linux/build-flatpak.sh
@@ -6,31 +6,5 @@ if [ ! -d "shared-modules" ]; then
 	git clone --depth 1 https://github.com/flathub/shared-modules.git
 fi
 
-cd .. # Go to Platforms folder
-
-echo Checking dependencies...
-
-mkdir -p Resources/linux-x64/native
-
-# cimgui_rX is the git tag for for the release we are usign of cimgui
-if [ ! -e "Resources/linux-x64/native/cimgui_r2" ]; then
-	echo Downloading Cimgui...
-	curl -L https://github.com/exelix11/CimguiSDL2Cross/releases/download/r2/linux-x64.zip -o linux-x64.zip
-	unzip linux-x64.zip
-	mv cimgui.so Resources/linux-x64/native/cimgui.so
-	echo ok > "Resources/linux-x64/native/cimgui_r2"
-fi
-
-cd .. # Go to client root
-dotnet publish -c Release -r linux-x64
-cd Platform/Linux
-
-if [ -d "dvr-build" ]; then
-	rm -rf dvr-build
-fi
-
-mkdir -p dvr-build
-cp -r ../../bin/Release/net9.0/linux-x64/publish/* dvr-build/
-
 flatpak-builder --user --install --install-deps-from=flathub tmp com.github.exelix11.sysdvr.json --force-clean
 flatpak build-bundle ~/.local/share/flatpak/repo SysDVR-Client.flatpak com.github.exelix11.sysdvr --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo

--- a/Client/Platform/Linux/com.github.exelix11.sysdvr.json
+++ b/Client/Platform/Linux/com.github.exelix11.sysdvr.json
@@ -3,6 +3,22 @@
 	"runtime": "org.freedesktop.Platform",
 	"runtime-version": "24.08",
 	"sdk": "org.freedesktop.Sdk",
+	"sdk-extensions": ["org.freedesktop.Sdk.Extension.dotnet9"],
+	"build-options": {
+		"build-args": ["--share=network"],
+		"append-path": "/usr/lib/sdk/dotnet9/bin",
+		"append-ld-library-path": "/usr/lib/sdk/dotnet9/lib",
+		"prepend-pkg-config-path": "/usr/lib/sdk/dotnet9/lib/pkgconfig",
+		"env": {
+			"DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+			"DOTNET_NOLOGO": "1"
+		},
+		"arch": {
+			"x86_64": {
+				"env": {"RUNTIME": "linux-x64"}
+			}
+		}
+	},
 	"command": "SysDVR-Client",
 	"finish-args": [
 		"--share=ipc",
@@ -26,10 +42,23 @@
 			],
 			"sources": [{
 			  "type": "archive",
-			  "url": "https://ffmpeg.org/releases/ffmpeg-5.1.6.tar.xz",
-			  "sha256": "f4fa066278f7a47feab316fef905f4db0d5e9b589451949740f83972b30901bd"
+			  "url": "https://ffmpeg.org/releases/ffmpeg-5.1.7.tar.xz",
+			  "sha256": "27d87965c5b0ab857a0092aeb9f55d975becb7126d83aefe39ae24102492180b"
 			}]
-		  },
+		},
+		{
+			"name": "nuget-sources",
+			"buildsystem": "simple",
+			"build-commands": ["dotnet restore -r $RUNTIME --packages /app/nuget-sources ./Client.csproj"],
+			"cleanup": ["/nuget-sources"],
+			"sources":
+			[
+				{
+					"type": "file",
+					"path": "../../Client.csproj"
+				}
+			]
+		},
 		{
 			"name": "sysdvr-client",
 			"buildsystem": "simple",
@@ -40,24 +69,25 @@
 				"ln -s /usr/lib/x86_64-linux-gnu/libSDL2_mixer-2.0.so.0 /app/lib/libSDL2_mixer.so",
 				"ln -s /usr/lib/x86_64-linux-gnu/libSDL2_net-2.0.so.0 /app/lib/libSDL2_net.so",
 				"ln -s /usr/lib/x86_64-linux-gnu/libSDL2_ttf-2.0.so.0 /app/lib/libSDL2_ttf.so",
-				"install -Dm644 com.github.exelix11.sysdvr.desktop /app/share/applications/com.github.exelix11.sysdvr.desktop",
-				"install -Dm644 flatpak_icon.png /app/share/icons/hicolor/256x256/apps/com.github.exelix11.sysdvr.png",
-				"cp -r dvr-build /app/bin"
+				"install -Dm644 ./Client/Platform/Linux/com.github.exelix11.sysdvr.desktop /app/share/applications/com.github.exelix11.sysdvr.desktop",
+				"install -Dm644 ./Client/Platform/Linux/flatpak_icon.png /app/share/icons/hicolor/256x256/apps/com.github.exelix11.sysdvr.png",
+				"mkdir -p ./Client/Platform/Resources/$RUNTIME/native",
+				"cp ./CimguiSDL2Cross/cimgui.so ./Client/Platform/Resources/$RUNTIME/native/cimgui.so",
+				"dotnet publish -c Release -r $RUNTIME --source /app/nuget-sources ./Client",
+				"cp -r ./Client/bin/Release/net*/$RUNTIME/publish /app/bin"
 			],
 			"sources":
 			[
 				{
 					"type": "dir",
-					"path": "dvr-build",
-					"dest": "dvr-build"
+					"path": "../../.."
 				},
 				{
-					"type": "file",
-					"path": "com.github.exelix11.sysdvr.desktop"
-				},
-				{
-					"type": "file",
-					"path": "flatpak_icon.png"
+					"type": "archive",
+					"url": "https://github.com/exelix11/CimguiSDL2Cross/releases/download/r2/linux-x64.zip",
+					"sha256": "d36d08d90e6f9c03a89c8e0739ffe8a49c4af004ed6755fc8b1a506598f6da4f",
+					"only-arches": ["x86_64"],
+					"dest": "CimguiSDL2Cross"
 				}
 			]
 		}


### PR DESCRIPTION
Hi, I've made some changes to the way the flatpak client is built:
- The client is now built within the flatpak environment. This was the main motivation for this change, to allow building it without needing to install dotnet on the host computer.
- The flatpak manifest now handles both the download of CimguiSDL2Cross, as well of the nuget dependencies. The separate `nuget-sources` module is required to allow flatpak-builder to automatically cache the dependencies. Without it, every run would re-download them from scratch.
- The `build-flatpak.sh` script has been greatly simplified, since almost everything is now handled directly by the json manifest.
- The github action workflow has been replaced almost completely. Now it uses the official flatpak github action, which handles almost everything automatically, including caching to speed up subsequent runs. The only manual step is the cloning of the shared-modules repo, used for libusb.
- ffmpeg has been updated to 5.1.7, the latest patch of the 5.1 series

I've tested these changes with the artifact generated here, everything seems to be working fine: https://github.com/Parnassius/SysDVR/actions/runs/17829281518